### PR TITLE
fix(mac): unable to paste files in some apps

### DIFF
--- a/src/platforms/macos/api.rs
+++ b/src/platforms/macos/api.rs
@@ -30,28 +30,7 @@ impl ClipboardOperations for RealClipboard {
     // 内容をクリア
     pasteboard.clear_contents();
 
-    // タイプを宣言
-    let file_url_type = ObjcString::from_str("public.file-url").ok_or_else(|| {
-      Error::new(
-        ErrorKind::Other,
-        "Failed to create NSString for file URL type",
-      )
-    })?;
-
-    let filenames_type = ObjcString::from_str("NSFilenamesPboardType").ok_or_else(|| {
-      Error::new(
-        ErrorKind::Other,
-        "Failed to create NSString for filenames type",
-      )
-    })?;
-
-    let types = vec![file_url_type.as_id(), filenames_type.as_id()];
-    let types_array = ObjcArray::from_vec(&types)
-      .ok_or_else(|| Error::new(ErrorKind::Other, "Failed to create types array"))?;
-
-    pasteboard.declare_types(&types_array);
-
-    // URLの配列を作成
+    // URLの配列を作成（writeObjectsが自動的にタイプを管理）
     let urls_array = ObjcArray::from_vec(&urls)
       .ok_or_else(|| Error::new(ErrorKind::Other, "Failed to create URLs array"))?;
 
@@ -132,34 +111,6 @@ pub fn write_clipboard_file_paths(paths: &[String]) -> Result<(), Error> {
   if !errors.is_empty() {
     let error_message = format!("Some paths could not be processed: {}", errors.join("; "));
     return Err(Error::new(ErrorKind::InvalidInput, error_message));
-  }
-
-  // クリップボードのタイプを設定
-  let file_url_type = ObjcString::from_str("public.file-url").ok_or_else(|| {
-    Error::new(
-      ErrorKind::Other,
-      "Failed to create NSString for file URL type",
-    )
-  })?;
-
-  let filenames_type = ObjcString::from_str("NSFilenamesPboardType").ok_or_else(|| {
-    Error::new(
-      ErrorKind::Other,
-      "Failed to create NSString for filenames type",
-    )
-  })?;
-
-  let types = vec![file_url_type.as_id(), filenames_type.as_id()];
-  let types_array = ObjcArray::from_vec(&types)
-    .ok_or_else(|| Error::new(ErrorKind::Other, "Failed to create types array"))?;
-
-  // タイプを宣言
-  let declared = pasteboard.declare_types(&types_array);
-  if !declared {
-    return Err(Error::new(
-      ErrorKind::Other,
-      "Failed to declare pasteboard types",
-    ));
   }
 
   // URLの配列を作成

--- a/src/platforms/macos/wrapper.rs
+++ b/src/platforms/macos/wrapper.rs
@@ -224,11 +224,6 @@ impl Pasteboard {
     unsafe { msg_send![self.pasteboard, clearContents] }
   }
 
-  /// ペーストボードにタイプを宣言
-  pub fn declare_types(&self, types_array: &ObjcArray) -> bool {
-    unsafe { msg_send![self.pasteboard, declareTypes:types_array.as_id() owner:nil] }
-  }
-
   /// ペーストボードにオブジェクトを書き込む
   pub fn write_objects(&self, objects_array: &ObjcArray) -> bool {
     unsafe { msg_send![self.pasteboard, writeObjects:objects_array.as_id()] }


### PR DESCRIPTION
In macOS 10.6 and later, the functionality of type declarations has been covered by `writeObjects(_:)`, so there is no need to call declare_types anymore. In previous implementations, calling declare_types caused issues with the clipboard data, resulting in the ability to paste files only in Finder, while pasting in apps like Slack and WeChat was not possible.

---

Correct:
<img width="1908" height="900" alt="CleanShot 2025-07-26 at 18 14 25" src="https://github.com/user-attachments/assets/d00f5ef0-c2a4-4348-8a10-bccc0a67b5d0" />

Incorrect:
<img width="1908" height="900" alt="CleanShot 2025-07-26 at 18 15 01" src="https://github.com/user-attachments/assets/5720e69a-081e-4c86-a247-25e6d6232a6b" />
