### PR TITLE
chore(ci): enable workflow triggers on version tags and update Node.js versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,8 +10,9 @@ permissions:
   push:
     branches:
       - main
-    tags-ignore:
-      - '**'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
     paths-ignore:
       - '**/*.md'
       - LICENSE
@@ -173,8 +174,9 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
         node:
-          - '18'
           - '20'
+          - '22'
+          - '24'
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -204,8 +206,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '18'
           - '20'
+          - '22'
+          - '24'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -234,8 +237,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '18'
           - '20'
+          - '22'
+          - '24'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -268,6 +272,7 @@ jobs:
         node:
           - '20'
           - '22'
+          - '24'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -351,12 +356,20 @@ jobs:
       - name: Publish
         run: |
           npm config set provenance true
-          if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
-          then
+          if [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Publishing stable version from tag: ${{ github.ref }}"
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access public
-          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
-          then
+          elif [[ "${{ github.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+- ]]; then
+            echo "Publishing pre-release version from tag: ${{ github.ref }}"
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            npm publish --tag next --access public
+          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$"; then
+            echo "Publishing stable version from commit message"
+            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            npm publish --access public
+          elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+"; then
+            echo "Publishing pre-release version from commit message"
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --tag next --access public
           else


### PR DESCRIPTION
## Summary
- Enable CI workflow triggers on version tags (vx.x.x format)
- Modernize Node.js test matrix to versions 20, 22, and 24
- Improve npm publish logic with tag-based detection

## Changes
### Tag-based CI Triggers
- Removed `tags-ignore: '**'` that was preventing tag triggers
- Added explicit tag patterns for stable (`v[0-9]+.[0-9]+.[0-9]+`) and pre-release (`v[0-9]+.[0-9]+.[0-9]+-*`) versions

### Enhanced Publishing Logic
- Prioritize tag-based publishing over commit message parsing
- Add clear logging to distinguish between tag and commit message triggers
- Support both stable and pre-release publishing based on tag format

### Node.js Version Updates
- Drop Node.js 18 (approaching end of maintenance)
- Add Node.js 24 for latest version compatibility testing
- Test matrix now includes: 20, 22, 24

## Test plan
- [x] CI workflow syntax is valid
- [ ] Tag push will trigger the workflow
- [ ] Publishing logic correctly identifies stable vs pre-release versions
- [ ] All Node.js versions in the test matrix are supported

🤖 Generated with [Claude Code](https://claude.ai/code)